### PR TITLE
Fix alignment

### DIFF
--- a/generate-package-notes.py
+++ b/generate-package-notes.py
@@ -4,7 +4,7 @@
 $ ./generate-package-notes.py --package-type rpm --package-name systemd --package-version 248~rc2-1.fc34 --cpe 'cpe:/o:fedoraproject:fedora:33'
 SECTIONS
 {
-    .note.package ALIGN(8): {
+    .note.package : ALIGN(4) {
         BYTE(0x04) BYTE(0x00) BYTE(0x00) BYTE(0x00) /* Length of Owner including NUL */
         BYTE(0x73) BYTE(0x00) BYTE(0x00) BYTE(0x00) /* Length of Value including NUL */
         BYTE(0x7e) BYTE(0x1a) BYTE(0xfe) BYTE(0xca) /* Note ID */
@@ -123,7 +123,7 @@ def encode_note(note_name, note_id, owner, value, prefix=''):
     l3 = encode_note_id(note_id, prefix=prefix + '    ')
     l4 = encode_string(owner, prefix=prefix + '    ', label='Owner')
     l5 = encode_string(value, prefix=prefix + '    ', label='Value')
-    return [prefix + f'.note.{note_name} ALIGN(8): {{',
+    return [prefix + f'.note.{note_name} : ALIGN(4) {{',
             l1, l2, l3, *l4, *l5,
             prefix + '}']
 


### PR DESCRIPTION
The linker format is picky but fails silently here, and objdump
shows the note is not aligned.
Fix position and whitespace and size of ALIGN field.